### PR TITLE
TawsiGO brand: map style + Profile (Security, Info, Help)

### DIFF
--- a/src/screens/Login/components/EmailLoginForm.js
+++ b/src/screens/Login/components/EmailLoginForm.js
@@ -179,8 +179,8 @@ const EmailLoginForm = ({ onLoginSuccess, hideForgetPassword }) => {
             height: 20,
             borderRadius: 4,
             borderWidth: 2,
-            borderColor: rememberMe ? '#000000' : '#D1D5DB',
-            backgroundColor: rememberMe ? '#000000' : 'transparent',
+            borderColor: rememberMe ? '#F37A1D' : '#D1D5DB',
+            backgroundColor: rememberMe ? '#F37A1D' : 'transparent',
             alignItems: 'center',
             justifyContent: 'center',
           }}>

--- a/src/screens/Login/components/ForgotPassword.js
+++ b/src/screens/Login/components/ForgotPassword.js
@@ -104,7 +104,7 @@ const ForgotPassword = () => {
         <View style={{ paddingTop: insets.top }}>
           <View style={loginStyles.header}>
             <TouchableOpacity style={loginStyles.closeButton} onPress={() => navigation.goBack()}>
-              <Icon name="close" size={24} color="#000000" />
+              <Icon name="close" size={24} color="#18365A" />
             </TouchableOpacity>
             <View style={{ width: 40, height: 40 }} />
           </View>

--- a/src/screens/Login/components/ResetCodeScreen.js
+++ b/src/screens/Login/components/ResetCodeScreen.js
@@ -51,7 +51,7 @@ const ResetCodeScreen = ({ route }) => {
         <View style={{ paddingTop: insets.top }}>
           <View style={loginStyles.header}>
             <TouchableOpacity style={loginStyles.closeButton} onPress={() => navigation.goBack()}>
-              <Icon name="close" size={24} color="#000000" />
+              <Icon name="close" size={24} color="#18365A" />
             </TouchableOpacity>
             <View style={{ width: 40, height: 40 }} />
           </View>
@@ -74,7 +74,7 @@ const ResetCodeScreen = ({ route }) => {
                 onTextChange={(text) => setCode(text)}
                 focusColor="#18365A"
                 focusStickBlinkingDuration={500}
-                textInputProps={{ style: { color: "#000" } }}
+                textInputProps={{ style: { color: "#18365A" } }}
                 theme={{
                   containerStyle: {
                     marginBottom: 32,
@@ -88,7 +88,7 @@ const ResetCodeScreen = ({ route }) => {
                   },
                   pinCodeTextStyle: {
                     fontSize: 20,
-                    color: "#000",
+                    color: "#18365A",
                   },
                 }}
               />

--- a/src/screens/Login/components/ResetPassword.js
+++ b/src/screens/Login/components/ResetPassword.js
@@ -97,7 +97,7 @@ const ResetPassword = ({route}) => {
               style={loginStyles.closeButton}
               onPress={() => navigation.goBack()}
             >
-              <Icon name="close" size={24} color="#000000" />
+              <Icon name="close" size={24} color="#18365A" />
             </TouchableOpacity>
             <View style={{ width: 40, height: 40 }} />
           </View>

--- a/src/screens/Login/index.js
+++ b/src/screens/Login/index.js
@@ -225,7 +225,7 @@ const Login = ({ navigation }) => {
             style={styles.closeButton}
             onPress={() => navigation.goBack()}
           >
-            <Icon name="close" size={24} color="#000000" />
+            <Icon name="close" size={24} color="#18365A" />
           </TouchableOpacity>
 
           <TouchableOpacity
@@ -291,9 +291,9 @@ const Login = ({ navigation }) => {
                 disabled={isAppleLoading}
               >
                 {isAppleLoading ? (
-                  <ActivityIndicator size="small" color="#000000" />
+                  <ActivityIndicator size="small" color="#18365A" />
                 ) : (
-                  <FontAwesome name="apple" size={24} color="#000000" />
+                  <FontAwesome name="apple" size={24} color="#18365A" />
                 )}
                 <Text style={styles.socialButtonText}>Apple</Text>
               </TouchableOpacity>

--- a/src/screens/Login/styles.js
+++ b/src/screens/Login/styles.js
@@ -48,7 +48,7 @@ export const styles = StyleSheet.create({
   welcomeTitle: {
     fontSize: 32,
     fontWeight: '700',
-    color: '#000000',
+    color: '#18365A',
     textAlign: 'center',
     marginBottom: 8,
     letterSpacing: -0.5,
@@ -72,10 +72,10 @@ export const styles = StyleSheet.create({
     position: 'absolute',
     width: '50%',
     height: '100%',
-    backgroundColor: '#000000',
+    backgroundColor: '#F37A1D',
     borderRadius: 12,
     borderWidth: 1,
-    borderColor: '#000000',
+    borderColor: '#F37A1D',
   },
   switchButton: {
     flex: 1,
@@ -156,7 +156,7 @@ export const styles = StyleSheet.create({
   btn: {
     width: '100%',
     paddingVertical: 18,
-    backgroundColor: '#000000',
+    backgroundColor: '#F37A1D',
     borderRadius: 16,
     alignItems: 'center',
     marginTop: 8,
@@ -220,7 +220,7 @@ export const styles = StyleSheet.create({
     textAlign: 'center',
   },
   registerNow: {
-    color: '#000000',
+    color: '#F37A1D',
     fontWeight: '700',
   },
   guestButton: {
@@ -250,7 +250,7 @@ export const styles = StyleSheet.create({
     borderTopColor: '#E5E7EB',
     ...Platform.select({
       ios: {
-        shadowColor: '#000',
+        shadowColor: '#F37A1D',
         shadowOpacity: 0.08,
         shadowRadius: 8,
         shadowOffset: { width: 0, height: -2 },

--- a/src/screens/MainScreen/index.js
+++ b/src/screens/MainScreen/index.js
@@ -18,6 +18,7 @@ import Icon from 'react-native-vector-icons/MaterialCommunityIcons';
 
 import {localStyles} from "./localStyles"
 import ClusterMapView from 'react-native-map-clustering';
+import { tawsiGOMapStyle } from '../../utils/mapStyle';
 import {Marker, PROVIDER_GOOGLE,Polyline} from 'react-native-maps';
 import MapViewDirections from 'react-native-maps-directions';
 import {useDispatch, useSelector} from 'react-redux';
@@ -79,7 +80,7 @@ import ActivationCountdown from '../../components/ActivationCountdown';
 const { width: SCREEN_WIDTH, height: SCREEN_HEIGHT } = Dimensions.get("screen");
 import ReactNativeHapticFeedback from "react-native-haptic-feedback";
 
-import mapStyle from '../../utils/googleMapStyle';
+
 import { useNavigation, useFocusEffect } from '@react-navigation/native';
 
  
@@ -1099,6 +1100,7 @@ const MainScreen = () => {
   const renderMap = () => {
     return (
       <ClusterMapView
+        customMapStyle={tawsiGOMapStyle}
         ref={mapRef}
         style={styles.mapContainer}
         provider={PROVIDER_GOOGLE}
@@ -1122,7 +1124,7 @@ const MainScreen = () => {
         rotateEnabled={false}
         pitchEnabled={false} 
         focusable
-        customMapStyle={mapStyle}
+
         showsUserLocation={true}
      showsMyLocationButton={false}
         onPanDrag={handleMapDrag}
@@ -1179,7 +1181,7 @@ const MainScreen = () => {
             mode='DRIVING'
             apikey={API_GOOGLE}
             strokeWidth={3}
-            strokeColor="#999"
+            strokeColor="#F37A1D"
             onReady={result => {
               if (backInterval.current) {
                 setAnimatedCoords([]);
@@ -1281,7 +1283,7 @@ const MainScreen = () => {
             onPress={() => navigation.openDrawer()}
             activeOpacity={0.7}
           >
-            <Icon name="menu" size={24} color="#000" />
+            <Icon name="menu" size={24} color="#18365A" />
           </TouchableOpacity>
         </View>
         

--- a/src/screens/Order/index.js
+++ b/src/screens/Order/index.js
@@ -23,6 +23,7 @@ import api from '../../utils/api';
 import MaterialCommunityIcons from 'react-native-vector-icons/MaterialCommunityIcons';
 import Ionicons from 'react-native-vector-icons/Ionicons';
 import MapView, { Marker, PROVIDER_GOOGLE } from 'react-native-maps';
+import { tawsiGOMapStyle } from '../../utils/mapStyle';
 import MapViewDirections from 'react-native-maps-directions';
 import { API_GOOGLE } from '@env';
  import OrderPlaceholder from '../../components/OrderPlaceholder';
@@ -606,6 +607,7 @@ const Order = ({ route }) => {
             <View style={styles.mapCard}>
               <MapView
                 ref={mapRef}
+                customMapStyle={tawsiGOMapStyle}
                 style={styles.orderMap}
                 provider={PROVIDER_GOOGLE}
                 showsCompass

--- a/src/screens/Profile/components/ImagePickerModal.js
+++ b/src/screens/Profile/components/ImagePickerModal.js
@@ -35,7 +35,7 @@ const ImagePickerModal = ({ isVisible, onClose, onCameraPress, onGalleryPress })
                   <Ionicons
                     name="camera-outline"
                     size={40}
-                    color={"#000"}
+                    color={colors.secondary}
                   />
                 </View>
                 <Text style={styles.optionText}>{t('profile.image_picker.camera')}</Text>
@@ -49,7 +49,7 @@ const ImagePickerModal = ({ isVisible, onClose, onCameraPress, onGalleryPress })
                   <Ionicons
                     name="images-outline"
                     size={40}
-                    color={"#000"}
+                    color={colors.secondary}
                   />
                 </View>
                 <Text style={styles.optionText}>{t('profile.image_picker.gallery')}</Text>
@@ -85,7 +85,7 @@ const styles = StyleSheet.create({
     borderTopLeftRadius: 20,
     borderTopRightRadius: 20,
     padding: hp(2),
-    shadowColor: '#000',
+    shadowColor: colors.primary,
     shadowOffset: {
       width: 0,
       height: -2,
@@ -101,7 +101,7 @@ const styles = StyleSheet.create({
   modalTitle: {
     fontSize: hp(2.2),
     fontWeight: '600',
-    color: "#000",
+    color: colors.secondary,
     marginBottom: hp(0.5),
   },
   modalSubtitle: {
@@ -129,7 +129,7 @@ const styles = StyleSheet.create({
   },
   optionText: {
     fontSize: hp(1.6),
-    color: "#000",
+    color: colors.secondary,
     fontWeight: '500',
   },
   cancelButton: {
@@ -139,7 +139,7 @@ const styles = StyleSheet.create({
     alignItems: 'center',
   },
   cancelButtonText: {
-    color: "#000",
+    color: colors.secondary,
     fontSize: hp(1.8),
     fontWeight: '600',
   },

--- a/src/screens/Profile/components/LanguageModal.js
+++ b/src/screens/Profile/components/LanguageModal.js
@@ -60,7 +60,7 @@ const LanguageModal = ({ isVisible, onClose, onLanguageSelect }) => {
             style={{ position: 'absolute', right: 15, top: 15, zIndex: 1 }}
             onPress={onClose}
           >
-            <Icon name="close" size={24} color="#000" />
+            <Icon name="close" size={24} color="#18365A" />
           </TouchableOpacity>
 
           <View style={styles.modalIconContainer}>

--- a/src/screens/Profile/components/OtpModal.js
+++ b/src/screens/Profile/components/OtpModal.js
@@ -194,7 +194,7 @@ const OtpModal = ({
     },
     progressFill: {
       height: '100%',
-      backgroundColor: '#000000',
+      backgroundColor: '#F37A1D',
       borderRadius: 2,
     },
     titleContainer: {
@@ -203,7 +203,7 @@ const OtpModal = ({
     title: {
       fontSize: 28,
       fontWeight: '700',
-      color: '#000000',
+      color: '#18365A',
       marginBottom: 12,
       textAlign: 'center',
     },
@@ -217,7 +217,7 @@ const OtpModal = ({
     phoneNumber: {
       fontSize: 18,
       fontWeight: '600',
-      color: '#000000',
+      color: '#18365A',
       textAlign: 'center',
     },
     otpContainer: {
@@ -237,7 +237,7 @@ const OtpModal = ({
       backgroundColor: '#FFFFFF',
     },
     otpInputFocused: {
-      borderColor: '#000000',
+      borderColor: '#F37A1D',
       backgroundColor: '#FAFAFA',
     },
     otpInputError: {
@@ -247,7 +247,7 @@ const OtpModal = ({
     otpInputText: {
       fontSize: 28,
       fontWeight: '700',
-      color: '#000000',
+      color: '#18365A',
     },
     errorContainer: {
       backgroundColor: '#FFF5F5',
@@ -290,8 +290,8 @@ const OtpModal = ({
       borderColor: '#E5E5E5',
     },
     resendButtonActive: {
-      backgroundColor: '#000000',
-      borderColor: '#000000',
+      backgroundColor: '#F37A1D',
+      borderColor: '#F37A1D',
     },
     resendButtonDisabled: {
       opacity: 0.5,
@@ -310,7 +310,7 @@ const OtpModal = ({
       marginTop: 8,
     },
     continueButton: {
-      backgroundColor: '#000000',
+      backgroundColor: '#F37A1D',
       borderRadius: 16,
       paddingVertical: 18,
       alignItems: 'center',
@@ -411,7 +411,7 @@ const OtpModal = ({
               <OtpInput
                 numberOfDigits={4}
                 onTextChange={(text) => setOtp(text)}
-                focusColor="#000000"
+                focusColor="#F37A1D"
                 focusStickBlinkingDuration={500}
                 theme={{
                   containerStyle: styles.otpInputContainer,

--- a/src/screens/Profile/components/ProfileSections.js
+++ b/src/screens/Profile/components/ProfileSections.js
@@ -154,7 +154,7 @@ const ProfileSections = ({
               <Icon
                 name={showCurrentPassword ? "eye-slash" : "eye"}
                 size={20}
-                color="#000"
+                color="#18365A"
               />
             </TouchableOpacity>
           </View>
@@ -187,7 +187,7 @@ const ProfileSections = ({
               <Icon
                 name={showNewPassword ? "eye-slash" : "eye"}
                 size={20}
-                color="#000"
+                color="#18365A"
               />
             </TouchableOpacity>
           </View>
@@ -223,7 +223,7 @@ const ProfileSections = ({
               <Icon
                 name={showConfirmPassword ? "eye-slash" : "eye"}
                 size={20}
-                color="#000"
+                color="#18365A"
               />
             </TouchableOpacity>
           </View>

--- a/src/screens/Profile/index.js
+++ b/src/screens/Profile/index.js
@@ -216,7 +216,7 @@ try {
           onPress={() => navigation.openDrawer()}
           activeOpacity={0.7}
         >
-          <MaterialCommunityIcons name="menu" size={24} color="#000" />
+          <MaterialCommunityIcons name="menu" size={24} color={colors.secondary} />
         </TouchableOpacity>
         
         <View style={styles.uberHeaderContent}>
@@ -251,7 +251,7 @@ try {
               {/* Upload Loading Overlay */}
               {isUploading && (
                 <View style={styles.uberUploadingOverlay}>
-                  <ActivityIndicator size="large" color="#000" />
+                  <ActivityIndicator size="large" color={colors.primary} />
                 </View>
               )}
               
@@ -305,7 +305,7 @@ try {
             >
               <View style={styles.uberMenuItemLeft}>
                 <View style={styles.uberMenuIconContainer}>
-                  <Ionicons name={button.icon} size={24} color="#000" />
+                  <Ionicons name={button.icon} size={24} color={colors.secondary} />
                 </View>
                 <View style={styles.uberMenuTextContainer}>
                   <Text style={styles.uberMenuItemTitle}>{button.title}</Text>
@@ -328,7 +328,7 @@ try {
           >
             <View style={styles.uberMenuItemLeft}>
               <View style={styles.uberMenuIconContainer}>
-                <Ionicons name="language-outline" size={24} color="#000" />
+                <Ionicons name="language-outline" size={24} color={colors.secondary} />
               </View>
               <View style={styles.uberMenuTextContainer}>
                 <Text style={styles.uberMenuItemTitle}>{t('profile.language.title')}</Text>

--- a/src/screens/Profile/sections/Help.js
+++ b/src/screens/Profile/sections/Help.js
@@ -80,7 +80,7 @@ const Help = () => {
     }
   };
 
-  const renderHelpOption = (icon, title, description, onPress, iconColor = "#007AFF") => (
+  const renderHelpOption = (icon, title, description, onPress, iconColor = "#F37A1D") => (
     <TouchableOpacity
       style={styles.uberHelpOption}
       onPress={onPress}
@@ -104,7 +104,7 @@ const Help = () => {
   const renderFAQItem = (question, answer) => (
     <View style={styles.uberFAQItem}>
       <View style={styles.uberFAQHeader}>
-        <Icon name="help-circle-outline" size={20} color="#007AFF" />
+        <Icon name="help-circle-outline" size={20} color="#F37A1D" />
         <Text style={styles.uberFAQQuestion}>{question}</Text>
       </View>
       <Text style={styles.uberFAQAnswer}>{answer}</Text>
@@ -141,7 +141,7 @@ const Help = () => {
             <Icon 
               name={I18nManager.isRTL ? "chevron-right" : "chevron-left"} 
               size={24} 
-              color="#000" 
+              color="#18365A" 
             />
           </TouchableOpacity>
           
@@ -161,7 +161,7 @@ const Help = () => {
           {/* Quick Actions Section */}
           <View style={styles.uberFormSection}>
             <View style={styles.uberSectionHeaderInline}>
-              <Icon name="flash-outline" size={24} color="#000" />
+              <Icon name="flash-outline" size={24} color="#18365A" />
               <Text style={styles.uberSectionHeaderTitle}>
                 {t('help.quick_actions', 'Quick Actions')}
               </Text>
@@ -172,14 +172,14 @@ const Help = () => {
               t('tickets.title', 'Support Tickets'),
               t('tickets.description', 'Create and manage support tickets'),
               () => currentUser ? navigation.navigate("TicketScreen") :navigation.navigate('NewTicketScreen'),
-              "#007AFF"
+              "#F37A1D"
             )}
           </View>
 
           {/* Contact Support Section */}
           <View style={styles.uberFormSection}>
             <View style={styles.uberSectionHeaderInline}>
-              <Icon name="headset" size={24} color="#000" />
+              <Icon name="headset" size={24} color="#18365A" />
               <Text style={styles.uberSectionHeaderTitle}>
                 {t('help.contact_support', 'Contact Support')}
               </Text>
@@ -193,7 +193,7 @@ const Help = () => {
                 t('help.contact.email', 'Email Support'),
                 'support@tawsilet.com',
                 handleEmail,
-                '#007AFF'
+                '#F37A1D'
               )}
 
             
@@ -203,7 +203,7 @@ const Help = () => {
           {/* FAQ Section */}
           <View style={styles.uberFormSection}>
             <View style={styles.uberSectionHeaderInline}>
-              <Icon name="frequently-asked-questions" size={24} color="#000" />
+              <Icon name="frequently-asked-questions" size={24} color="#18365A" />
               <Text style={styles.uberSectionHeaderTitle}>
                 {t('help.faq.title', 'Frequently Asked Questions')}
               </Text>
@@ -233,7 +233,7 @@ const Help = () => {
           {/* App Information Section */}
           <View style={styles.uberFormSection}>
             <View style={styles.uberSectionHeaderInline}>
-              <Icon name="information-outline" size={24} color="#000" />
+              <Icon name="information-outline" size={24} color="#18365A" />
               <Text style={styles.uberSectionHeaderTitle}>
                 {t('help.app_info', 'App Information')}
               </Text>
@@ -272,7 +272,7 @@ const Help = () => {
                     <Text style={styles.uberAppInfoLabel}>
                       {t('help.latest_version', 'Latest Version')}
                     </Text>
-                    <Text style={[styles.uberAppInfoValue, { color: '#007AFF' }]}>
+                    <Text style={[styles.uberAppInfoValue, { color: '#F37A1D' }]}>
                       {latestVersion}
                     </Text>
                   </View>
@@ -281,7 +281,7 @@ const Help = () => {
                   
                   <TouchableOpacity
                     style={{
-                      backgroundColor: '#007AFF',
+                      backgroundColor: '#F37A1D',
                       paddingVertical: 12,
                       paddingHorizontal: 20,
                       borderRadius: 8,

--- a/src/screens/Profile/sections/PersonalInfo.js
+++ b/src/screens/Profile/sections/PersonalInfo.js
@@ -48,7 +48,7 @@ const PersonalInfo = () => {
       <View style={{ padding: 20, flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center', borderBottomWidth: 1, borderBottomColor: '#f0f0f0' }}>
         <Text style={{ fontSize: 18, fontWeight: 'bold' }}>{t('profile.personal_info.select_country')}</Text>
         <TouchableOpacity onPress={() => setFlagsVisible(false)}>
-          <Icon name="close" size={24} color="#000" />
+          <Icon name="close" size={24} color="#18365A" />
         </TouchableOpacity>
       </View>
       <View style={{ paddingHorizontal: 20, paddingBottom: 20, paddingTop: 10,height:90 }}>
@@ -266,7 +266,7 @@ const PersonalInfo = () => {
                 <MaterialCommunityIcons 
                   name={I18nManager.isRTL ? "chevron-right" : "chevron-left"} 
                   size={24} 
-                  color="#000" 
+                  color="#18365A" 
                 />
               </TouchableOpacity>
               
@@ -284,7 +284,7 @@ const PersonalInfo = () => {
               {/* Personal Information Section */}
               <View style={styles.uberFormSection}>
                 <View style={styles.uberSectionHeaderInline}>
-                  <MaterialCommunityIcons name="account-outline" size={24} color="#000" />
+                  <MaterialCommunityIcons name="account-outline" size={24} color="#18365A" />
                   <Text style={styles.uberSectionHeaderTitle}>
                     {t("profile.personal_info.section_title", "Personal Information")}
                   </Text>
@@ -348,7 +348,7 @@ const PersonalInfo = () => {
               {/* Information Notice */}
               <View style={styles.uberNoticeContainer}>
                 <View style={styles.uberNoticeIconContainer}>
-                  <MaterialCommunityIcons name="information-outline" size={20} color="#007AFF" />
+                  <MaterialCommunityIcons name="information-outline" size={20} color="#F37A1D" />
                 </View>
                 <Text style={styles.uberNoticeText}>
                   {t("profile.personal_info.notice", "Changes to your phone number will require verification via SMS.")}

--- a/src/screens/Profile/sections/Security.js
+++ b/src/screens/Profile/sections/Security.js
@@ -189,7 +189,7 @@ const Security = () => {
   const renderSecurityTip = (icon, title, description) => (
     <View style={styles.uberSecurityTip}>
       <View style={styles.uberSecurityTipIcon}>
-        <Icon name={icon} size={20} color="#007AFF" />
+        <Icon name={icon} size={20} color="#F37A1D" />
       </View>
       <View style={styles.uberSecurityTipContent}>
         <Text style={styles.uberSecurityTipTitle}>{title}</Text>
@@ -216,7 +216,7 @@ const Security = () => {
                 <Icon 
                   name={I18nManager.isRTL ? "chevron-right" : "chevron-left"} 
                   size={24} 
-                  color="#000" 
+                  color="#18365A" 
                 />
               </TouchableOpacity>
               
@@ -238,7 +238,7 @@ const Security = () => {
               {/* Password Change Section */}
               <View style={styles.uberFormSection}>
                 <View style={styles.uberSectionHeaderInline}>
-                  <Icon name="shield-check-outline" size={24} color="#000" />
+                  <Icon name="shield-check-outline" size={24} color="#18365A" />
                   <Text style={styles.uberSectionHeaderTitle}>
                     {t('profile.security.change_password', 'Change Password')}
                   </Text>
@@ -272,7 +272,7 @@ const Security = () => {
               {/* Security Tips Section */}
               <View style={styles.uberFormSection}>
                 <View style={styles.uberSectionHeaderInline}>
-                  <Icon name="lightbulb-outline" size={24} color="#000" />
+                  <Icon name="lightbulb-outline" size={24} color="#18365A" />
                   <Text style={styles.uberSectionHeaderTitle}>
                     {t('profile.security.tips_title', 'Security Tips')}
                   </Text>

--- a/src/screens/TrackingScreen/index.js
+++ b/src/screens/TrackingScreen/index.js
@@ -18,6 +18,7 @@ import { useTranslation } from 'react-i18next';
 import MaterialCommunityIcons from 'react-native-vector-icons/MaterialCommunityIcons';
 import Ionicons from 'react-native-vector-icons/Ionicons';
 import MapView, { Marker, Polyline, PROVIDER_GOOGLE } from 'react-native-maps';
+import { tawsiGOMapStyle } from '../../utils/mapStyle';
 import MapViewDirections from 'react-native-maps-directions';
 import { API_GOOGLE } from '@env';
 import api from '../../utils/api';
@@ -604,20 +605,22 @@ const TrackingScreen = ({ route }) => {
 
   // Get route color based on status and mode
   const getRouteColor = useCallback((status, is3D = false) => {
-    // Restrict to black/white/gray palette only
     if (is3D) {
-      return '#000000'; // Black for 3D mode
+      return '#F37A1D';
     }
     switch (status) {
+      case 'Pending':
+      case 'Assigned_to_driver':
+      case 'Driver_on_route_to_pickup':
       case 'Go_to_pickup':
-        return '#999999'; // Gray
+      case 'Arrived_at_pickup':
+        return '#18365A';
       case 'Picked_up':
       case 'On_route_to_delivery':
-        return '#000000'; // Black
-      case 'Arrived_at_pickup':
-        return '#666666'; // Dark Gray
+      case 'Arrived_at_delivery':
+        return '#F37A1D';
       default:
-        return '#000000'; // Default to black
+        return '#18365A';
     }
   }, []);
 
@@ -631,7 +634,7 @@ const TrackingScreen = ({ route }) => {
       <SafeAreaView style={styles.container}>
         <StatusBar barStyle="dark-content" backgroundColor="#ffffff" />
         <View style={styles.loadingContainer}>
-          <ActivityIndicator size="large" color="#000000" />
+          <ActivityIndicator size="large" color="#F37A1D" />
           <Text style={styles.loadingText}>{t('tracking.loading')}</Text>
         </View>
       </SafeAreaView>
@@ -643,7 +646,7 @@ const TrackingScreen = ({ route }) => {
       <SafeAreaView style={styles.container}>
         <StatusBar barStyle="dark-content" backgroundColor="#ffffff" />
         <View style={styles.errorContainer}>
-          <MaterialCommunityIcons name="alert-circle" size={64} color="#000000" />
+          <MaterialCommunityIcons name="alert-circle" size={64} color="#18365A" />
           <Text style={styles.errorText}>{error}</Text>
           <TouchableOpacity style={styles.retryButton} onPress={fetchOrder}>
             <Text style={styles.retryButtonText}>{t('common.retry')}</Text>
@@ -663,7 +666,7 @@ const TrackingScreen = ({ route }) => {
           style={styles.backButton} 
           onPress={() => navigation.goBack()}
         >
-          <MaterialCommunityIcons name={I18nManager.isRTL ? "arrow-right" : "arrow-left"} size={24} color="#000000" />
+          <MaterialCommunityIcons name={I18nManager.isRTL ? "arrow-right" : "arrow-left"} size={24} color="#18365A" />
         </TouchableOpacity>
         <Text style={styles.headerTitle}>
           {t('tracking.title')}
@@ -677,6 +680,7 @@ const TrackingScreen = ({ route }) => {
           ref={mapRef}
           style={styles.map}
           provider={PROVIDER_GOOGLE}
+          customMapStyle={tawsiGOMapStyle}
           onMapReady={() => setMapReady(true)}
           showsCompass={true}
           pitchEnabled={true}
@@ -775,7 +779,7 @@ const TrackingScreen = ({ route }) => {
               }}
             >
               <View style={[styles.locationMarker, styles.pickupMarker]}>
-                <MaterialCommunityIcons name="map-marker" size={30} color="#000000" />
+                <MaterialCommunityIcons name="map-marker" size={30} color="#F37A1D" />
               </View>
             </Marker>
           )}
@@ -790,7 +794,7 @@ const TrackingScreen = ({ route }) => {
               }}
             >
               <View style={[styles.locationMarker, styles.dropoffMarker]}>
-                <MaterialCommunityIcons name="flag-checkered" size={30} color="#000000" />
+                <MaterialCommunityIcons name="flag-checkered" size={30} color="#18365A" />
               </View>
             </Marker>
           )}
@@ -806,7 +810,7 @@ const TrackingScreen = ({ route }) => {
             <MaterialCommunityIcons 
               name="crosshairs-gps" 
               size={24} 
-              color={isFollowingDriver ? '#000000' : '#666666'} 
+              color={isFollowingDriver ? '#F37A1D' : '#18365A'} 
             />
             {isFollowingDriver && (
               <View style={styles.controlButtonIndicator}>
@@ -817,7 +821,7 @@ const TrackingScreen = ({ route }) => {
          
           
           <TouchableOpacity style={styles.controlButton} onPress={focusOnAllCoordinates}>
-            <MaterialCommunityIcons name="map-marker-multiple" size={24} color="#666666" />
+            <MaterialCommunityIcons name="map-marker-multiple" size={24} color="#18365A" />
           </TouchableOpacity>
 
           
@@ -838,7 +842,7 @@ const TrackingScreen = ({ route }) => {
         
         {isFocusingOnAllCoordinates && (
           <View style={styles.statusFocusIndicator}>
-            <MaterialCommunityIcons name="map-marker-multiple" size={12} color="#007AFF" />
+            <MaterialCommunityIcons name="map-marker-multiple" size={12} color="#18365A" />
             <Text style={styles.statusFocusText}>{t('tracking.focusing')}</Text>
           </View>
         )}

--- a/src/utils/mapStyle.js
+++ b/src/utils/mapStyle.js
@@ -1,0 +1,22 @@
+export const tawsiGOMapStyle = [
+  { elementType: 'geometry', stylers: [{ color: '#f5f5f5' }] },
+  { elementType: 'labels.icon', stylers: [{ visibility: 'off' }] },
+  { elementType: 'labels.text.fill', stylers: [{ color: '#616161' }] },
+  { elementType: 'labels.text.stroke', stylers: [{ color: '#f5f5f5' }] },
+  { featureType: 'administrative.land_parcel', elementType: 'labels.text.fill', stylers: [{ color: '#bdbdbd' }] },
+  { featureType: 'poi', elementType: 'geometry', stylers: [{ color: '#eeeeee' }] },
+  { featureType: 'poi', elementType: 'labels.text.fill', stylers: [{ color: '#757575' }] },
+  { featureType: 'poi.park', elementType: 'geometry', stylers: [{ color: '#e5f2ef' }] },
+  { featureType: 'poi.park', elementType: 'labels.text.fill', stylers: [{ color: '#6b9a76' }] },
+  { featureType: 'road', elementType: 'geometry', stylers: [{ color: '#ffffff' }] },
+  { featureType: 'road.arterial', elementType: 'geometry', stylers: [{ color: '#ffffff' }] },
+  { featureType: 'road.arterial', elementType: 'labels.text.fill', stylers: [{ color: '#757575' }] },
+  { featureType: 'road.highway', elementType: 'geometry', stylers: [{ color: '#f8efe7' }] },
+  { featureType: 'road.highway', elementType: 'geometry.stroke', stylers: [{ color: '#f0e3d6' }] },
+  { featureType: 'road.highway', elementType: 'labels.text.fill', stylers: [{ color: '#616161' }] },
+  { featureType: 'road.local', elementType: 'labels.text.fill', stylers: [{ color: '#9e9e9e' }] },
+  { featureType: 'transit.line', elementType: 'geometry', stylers: [{ color: '#e5e5e5' }] },
+  { featureType: 'transit.station', elementType: 'geometry', stylers: [{ color: '#eeeeee' }] },
+  { featureType: 'water', elementType: 'geometry', stylers: [{ color: '#e3eef9' }] },
+  { featureType: 'water', elementType: 'labels.text.fill', stylers: [{ color: '#9e9e9e' }] }
+];


### PR DESCRIPTION
Title: TawsiGO brand polish — map style everywhere + Profile (Security, Info, Help)

Summary
- Apply TawsiGO brand colors across remaining areas
- Fix map style so all MapView instances use the new custom style
- Polish Profile subsections (Security, Personal Info/Information, Help/Aide)

Details
1) Map styling
- Created src/utils/mapStyle.js with TawsiGO customMapStyle (light, clean, subdued POIs) and applied it to:
  - MainScreen (ClusterMapView)
  - Order
  - TrackingScreen
- Fixed MainScreen duplicate customMapStyle prop that was overriding the new style
- Standardized route colors for MapViewDirections/markers:
  - Route to pickup: secondary #18365A
  - Route after pickup: primary #F37A1D
  - 3D or emphasized routes: primary #F37A1D
  - Pickup marker: primary, Dropoff marker: secondary

2) Profile screens
- Security: Replaced legacy blue (#007AFF) accents with brand primary #F37A1D for tips icons; header/back keeps secondary #18365A
- PersonalInfo (Information): Confirmed header/back, section icons, notice accent use brand (#F37A1D/#18365A)
- Help (Aide): Updated header/back to secondary; section header icons to secondary; quick actions and contact/email accent to primary. Kept existing support address until a new domain is provided.

3) Misc polish
- MainScreen header menu icon switched from black to secondary #18365A
- TrackingScreen controls: follow active icon now primary; secondary when idle; focusing indicator icon now secondary instead of blue

Scope/Safety
- UI-only changes — no business logic was altered
- All edits are limited to styles, icon colors, and MapView props

Follow-ups (optional)
- If you want a darker map or stronger brand tint, provide a reference and I can tweak src/utils/mapStyle.js accordingly
- If you have updated TawsiGO logo assets, I can replace the old tawsilet images used in a few headers
- If desired, I can sweep remaining neutral blacks in Profile styles to keep titles secondary and CTAs primary, while preserving readability for body text


₍ᐢ•(ܫ)•ᐢ₎ Generated by [Capy](https://capy.ai) ([view task](https://capy.ai/project/625122e1-74cb-4b38-a7f5-12b85a672ceb/task/1286b92f-f2db-40aa-8470-7f1a850c0305))